### PR TITLE
correctly vertical-align for FF too

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -13,7 +13,7 @@ ul li::marker {
     text-shadow: 0 1px 1px rgba(0, 0, 0, 0.1), 0 0 5px rgba(181, 232, 83, 0.1), 0 0 10px rgba(181, 232, 83, 0.1);
 }
 
-.logo {
+.logo, .logo img {
     vertical-align: middle;
 }
 

--- a/index.md
+++ b/index.md
@@ -69,6 +69,7 @@ We need a production-ready [overlay network](https://en.wikipedia.org/wiki/Overl
     * Mobility is defined as 50 randomly placed nodes in a 1x1km square, each randomly moving 10m every 10s
     * Mobility testing is performed for 60 iterations of node movement
     * Packet arrival performance is measured using pings between a subset of randomly selected nodes at least 2 hops apart at each mobility step
+
 ### Matrix
 
 We need to improve the Federation protocol to work with servers which frequently go offline and may have 1000s of servers (p2p nodes) in each room.

--- a/index.md
+++ b/index.md
@@ -66,8 +66,8 @@ We need a production-ready [overlay network](https://en.wikipedia.org/wiki/Overl
     * 🚧 Root hijacking attacks
     * 🚧 Malicious packet drop attacks
 - ✅ Good (>80% median) packet arrival performance in Mobility tests
-    * Mobility is defined as 50 randomly placed nodes in a 1x1km square, each randomly moving 10m every 10s
-    * Mobility testing is performed for 60 iterations of node movement
+    * Mobility is defined as 50 randomly placed nodes in a 1x1km square, each randomly moving 0-20m every 10s
+    * Mobility testing is performed for 360 iterations of node movement
     * Packet arrival performance is measured using pings between a subset of randomly selected nodes at least 2 hops apart at each mobility step
 
 ### Matrix

--- a/index.md
+++ b/index.md
@@ -1,7 +1,7 @@
 ---
 image: https://arewep2pyet.com/assets/images/logo.png
 ---
-[![Matrix](/assets/images/matrix-logo-white.svg)](https://matrix.org){: .logo} _Last updated: 2022-04-14_
+[![Matrix](/assets/images/matrix-logo-white.svg)](https://matrix.org){: .logo} _Last updated: 2022-04-16_
 
 ```
                                         ____                      _   ___ 

--- a/index.md
+++ b/index.md
@@ -1,7 +1,7 @@
 ---
 image: https://arewep2pyet.com/assets/images/logo.png
 ---
-[![Matrix](/assets/images/matrix-logo-white.svg)](https://matrix.org){: .logo} _Last updated: 2022-04-06_
+[![Matrix](/assets/images/matrix-logo-white.svg)](https://matrix.org){: .logo} _Last updated: 2022-04-14_
 
 ```
                                         ____                      _   ___ 

--- a/index.md
+++ b/index.md
@@ -1,15 +1,15 @@
 ---
 image: https://arewep2pyet.com/assets/images/logo.png
 ---
-[![Matrix](/assets/images/matrix-logo-white.svg)](https://matrix.org){: .logo} _Last updated: 2022-05-17_
+[![Matrix](/assets/images/matrix-logo-white.svg)](https://matrix.org){: .logo} _Last updated: 2022-07-11_
 
 ```
-                                        ____                      _   ___ 
+                                        ____                      _   ___
   __ _ _ __ ___   __      _____    _ __|___ \ _ __     _   _  ___| |_/ _ \
  / _` | '__/ _ \  \ \ /\ / / _ \  | '_ \ __) | '_ \   | | | |/ _ \ __\// /
-| (_| | | |  __/   \ V  V /  __/  | |_) / __/| |_) |  | |_| |  __/ |_  \/ 
- \__,_|_|  \___|    \_/\_/ \___|  | .__/_____| .__/    \__, |\___|\__| () 
-                                  |_|        |_|       |___/                
+| (_| | | |  __/   \ V  V /  __/  | |_) / __/| |_) |  | |_| |  __/ |_  \/
+ \__,_|_|  \___|    \_/\_/ \___|  | .__/_____| .__/    \__, |\___|\__| ()
+                                  |_|        |_|       |___/
 ```
 
 # Not Yet.
@@ -22,21 +22,22 @@ Our aims are to:
 
 Track the progress of P2P [Matrix](https://matrix.org) and join us at [#p2p:matrix.org](https://matrix.to/#/#p2p:matrix.org).
 
-### Dendrite 
+### Dendrite
 
 We need a fully-featured production-ready homeserver which can be embedded into a range of clients, from mobile devices to web browsers.
 
 <!-- TODO: Automatically generate -->
-- Synapse parity: (as of [05607d6](https://github.com/matrix-org/dendrite/runs/6457142794?check_suite_focus=true))
+- Synapse parity: (as of [3ea2127](https://github.com/matrix-org/dendrite/commit/3ea21273bcc151b36eec412d0ec550642fe9b04f))
     * 🚧 Client-Server API: 86%, aim: >90%
-    * 🚧 Server-Server API: 93%, aim: 100%
+    * 🚧 Server-Server API: 95%, aim: 100%
+    * 🚧 Application-Server API: 68%
 - Embeddability:
     * ✅ Embeddable database (SQLite3)
     * ✅ WASM
     * ✅ Android
     * ✅ iOS
 - Performance:
-    * ❌ Ensure memory usage of embedded instances is bounded e.g cache sizes.
+    * 🚧 Ensure memory usage of embedded instances is bounded e.g cache sizes.
     * ❌ Ensure CPU usage of embedded instances is bounded e.g # spawned goroutines.
 - Stability and Maintenance:
     * 🚧 Test coverage >=80% for code used in embedded instances: 72.4% (as of [05607d6](https://github.com/matrix-org/dendrite/commit/05607d6b8734738bd5c32288e3d0ef8e827d11d0), sytest coverage only, excludes Complement and unit tests)
@@ -57,14 +58,14 @@ We need a production-ready [overlay network](https://en.wikipedia.org/wiki/Overl
 - Works on a range of transports:
     * ✅ Public internet
     * ✅ LANs
-    * ✅ Bluetooth LE 
+    * ✅ Bluetooth LE
 - Resilience to adversarial attacks:
-    * 🚧 Sybil attacks
-    * 🚧 Eclipse attacks
-    * 🚧 Keyspace collision attacks
+    * ✅ Sybil attacks
+    * ✅ Eclipse attacks
+    * ✅ Keyspace collision attacks
     * 🚧 Churn attacks
     * 🚧 Root hijacking attacks
-    * 🚧 Malicious packet drop attacks
+    * ✅ Malicious packet drop attacks
 - ✅ Good (>80% median) packet arrival performance in Mobility tests
     * Mobility is defined as 50 randomly placed nodes in a 1x1km square, each randomly moving 0-20m every 10s
     * Mobility testing is performed for 360 iterations of node movement

--- a/index.md
+++ b/index.md
@@ -70,6 +70,7 @@ We need a production-ready [overlay network](https://en.wikipedia.org/wiki/Overl
     * Mobility is defined as 50 randomly placed nodes in a 1x1km square, each randomly moving 0-20m every 10s
     * Mobility testing is performed for 360 iterations of node movement
     * Packet arrival performance is measured using pings between a subset of randomly selected nodes at least 2 hops apart at each mobility step
+- 🚧 Scales to meet global demand
 
 ### Matrix
 

--- a/index.md
+++ b/index.md
@@ -1,7 +1,7 @@
 ---
 image: https://arewep2pyet.com/assets/images/logo.png
 ---
-[![Matrix](/assets/images/matrix-logo-white.svg)](https://matrix.org){: .logo} _Last updated: 2022-04-16_
+[![Matrix](/assets/images/matrix-logo-white.svg)](https://matrix.org){: .logo} _Last updated: 2022-05-17_
 
 ```
                                         ____                      _   ___ 
@@ -27,9 +27,9 @@ Track the progress of P2P [Matrix](https://matrix.org) and join us at [#p2p:matr
 We need a fully-featured production-ready homeserver which can be embedded into a range of clients, from mobile devices to web browsers.
 
 <!-- TODO: Automatically generate -->
-- Synapse parity: (as of [f7109de](https://github.com/matrix-org/dendrite/runs/5836736553?check_suite_focus=true))
-    * 🚧 Client-Server API: 81%, aim: >90%
-    * 🚧 Server-Server API: 94%, aim: 100%
+- Synapse parity: (as of [05607d6](https://github.com/matrix-org/dendrite/runs/6457142794?check_suite_focus=true))
+    * 🚧 Client-Server API: 86%, aim: >90%
+    * 🚧 Server-Server API: 93%, aim: 100%
 - Embeddability:
     * ✅ Embeddable database (SQLite3)
     * ✅ WASM
@@ -39,7 +39,7 @@ We need a fully-featured production-ready homeserver which can be embedded into 
     * ❌ Ensure memory usage of embedded instances is bounded e.g cache sizes.
     * ❌ Ensure CPU usage of embedded instances is bounded e.g # spawned goroutines.
 - Stability and Maintenance:
-    * 🚧 Test coverage >=80% for code used in embedded instances: ??% (as of xxxx) <!-- TODO: Automatically generate -->
+    * 🚧 Test coverage >=80% for code used in embedded instances: 72.4% (as of [05607d6](https://github.com/matrix-org/dendrite/commit/05607d6b8734738bd5c32288e3d0ef8e827d11d0), sytest coverage only, excludes Complement and unit tests)
     * 🚧 Active and timely (<7d) triage over main issue tracker.
     * 🚧 dendrite.matrix.org metrics are healthy (Sentry, Prometheus)
 
@@ -75,7 +75,9 @@ We need a production-ready [overlay network](https://en.wikipedia.org/wiki/Overl
 We need to improve the Federation protocol to work with servers which frequently go offline and may have 1000s of servers (p2p nodes) in each room.
 
 - ❌ Implement comprehensive Store-and-Forward event routing capabilities in Matrix to allow nodes to talk to each other even if they aren't online at the same time. Matrix currently has limited support for this via backfilling events.
-- ❌ Improve [event authentication rules](https://spec.matrix.org/unstable/server-server-api/#checks-performed-on-receipt-of-a-pdu) when the majority of nodes in the room are unreachable.
+- 🚧 Improve [event authentication rules](https://spec.matrix.org/unstable/server-server-api/#checks-performed-on-receipt-of-a-pdu) when the majority of nodes in the room are unreachable.
+    * Change the protocol to include a State/Auth DAG in addition to a normal Room DAG, and ensure that the Auth DAG is shared with all servers in the room. This allows servers to authenticate any incoming event without needing to make additional API calls.
+    * Change the protocol to eagerly connect to servers to ensure we rapidly synchronise Auth DAGs, rather than waiting until the user sends a message.
 - ❌ Improve [semantic delivery of old events to clients](https://github.com/matrix-org/matrix-spec/issues/852) to ensure that when old nodes come online clients don't see lots of old messages.
 - ❌ Support delivery of push notifications to P2P devices
 - ❌ Extension: Improve delivery of media uploads (content ID based?)


### PR DESCRIPTION
On a "Mozilla/5.0 (X11; Linux x86_64; rv:101.0) Gecko/20100101
Firefox/101.0" the "Last updated" text was lower than the "matrix" text
in the logo img.

![screenshot of the problem described above before being fixed](https://user-images.githubusercontent.com/25263210/183299898-8d6890f5-c31e-4fb9-b143-0f41a6eab9a8.png)

Tried building but it wasn't cooperating, so here's the same change applied manually in DevTools:

![same as before but it's more aligned now, though still imperfect](https://user-images.githubusercontent.com/25263210/183299934-77993ef2-e91f-481b-9c27-7f4b331932ca.png)
